### PR TITLE
fix: restore proper role-based access control in ProtectedRoleRoute

### DIFF
--- a/components/ProtectedRoleRoute.tsx
+++ b/components/ProtectedRoleRoute.tsx
@@ -18,5 +18,9 @@ export const ProtectedRoleRoute: React.FC<ProtectedRoleRouteProps> = ({
     ? requiredRole.includes(user?.role as any)
     : user?.role === requiredRole || (requiredRole === 'manager' && user?.role === 'admin') || (requiredRole === 'admin' && user?.role === 'manager');
 
+  if (!user || !hasRequiredRole) {
+    return <>{fallback}</>;
+  }
+
   return <>{children}</>;
 };


### PR DESCRIPTION
- Fix critical bug where ProtectedRoleRoute always rendered children regardless of role check
- Restore conditional logic to properly enforce manager/admin access to protected routes
- Maintain existing role hierarchy where admin and manager have equivalent permissions