### PR TITLE
feat: add global theme switcher

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,8 @@ import { ProtectedRoleRoute } from './components/ProtectedRoleRoute';
 import { AuthScreen } from './components/Auth';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { EulaModal } from './components/EulaModal';
+import { ThemeSwitcher } from './components/ThemeSwitcher';
+import { useTheme } from './hooks/useTheme';
 import type { Client } from './types';
 
 
@@ -199,11 +201,28 @@ const AppContent: React.FC = () => {
     return <CrmApp userName={user.name} onLogout={logout} userRole={user.role} />;
 };
 
-
 const App: React.FC = () => {
+    const { theme, toggleTheme } = useTheme();
+
+    useEffect(() => {
+        const root = document.documentElement;
+        if (theme === 'dark') {
+            root.classList.add('dark');
+        } else {
+            root.classList.remove('dark');
+        }
+    }, [theme]);
+
     return (
         <AuthProvider>
-            <AppContent />
+            <div className="min-h-screen bg-system-bg-secondary flex flex-col">
+                <header className="bg-system-bg-secondary/80 backdrop-blur-md border-b border-system-separator/50 p-4 flex justify-end">
+                    <ThemeSwitcher theme={theme} toggleTheme={toggleTheme} />
+                </header>
+                <main className="flex-grow">
+                    <AppContent />
+                </main>
+            </div>
         </AuthProvider>
     );
 };

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -13,12 +13,6 @@ export const useTheme = () => {
     }, []);
 
     useEffect(() => {
-        const root = window.document.documentElement;
-        if (theme === 'dark') {
-            root.classList.add('dark');
-        } else {
-            root.classList.remove('dark');
-        }
         localStorage.setItem('theme', theme);
     }, [theme]);
 

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
 }
 </script>
 </head>
-<body class="bg-system-bg-secondary antialiased dark">
+<body class="bg-system-bg-secondary antialiased">
 <div id="root"></div>
 <script type="module" src="/index.tsx"></script>
 </body>


### PR DESCRIPTION
## Summary
- integrate theme hook and global theme switcher header
- remove default dark body class
- manage theme via documentElement class

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Unexpected export in services/api.ts)


------
https://chatgpt.com/codex/tasks/task_e_68ac820107208330b41788b9d9f87fbf