### PR TITLE
feat: apply glassmorphism styling

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -7,19 +7,19 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 export const Button: React.FC<ButtonProps> = ({ children, variant = 'primary', size = 'default', className, ...props }) => {
-    const baseClasses = 'inline-flex items-center justify-center rounded-lg font-semibold transition-all focus:outline-none focus:ring-2 focus:ring-apple-blue focus:ring-offset-2 dark:focus:ring-offset-system-bg-secondary disabled:opacity-50 disabled:cursor-not-allowed';
+    const baseClasses = 'w-full sm:w-auto inline-flex items-center justify-center rounded-xl font-semibold transition-all backdrop-blur-md focus:outline-none focus:ring-2 focus:ring-apple-blue focus:ring-offset-2 dark:focus:ring-offset-system-bg-secondary disabled:opacity-50 disabled:cursor-not-allowed';
 
     const variantClasses = {
-        primary: 'bg-apple-blue text-white hover:brightness-110 active:brightness-90',
-        secondary: 'bg-system-fill-primary text-system-label-primary hover:bg-system-fill-secondary active:brightness-95 dark:active:brightness-105',
-        ghost: 'text-apple-blue hover:bg-apple-blue/10 active:bg-apple-blue/20',
+        primary: 'bg-apple-blue/80 text-white border border-white/20 hover:bg-apple-blue/90 active:bg-apple-blue/70',
+        secondary: 'bg-white/20 dark:bg-system-fill-primary/20 text-system-label-primary border border-white/20 hover:bg-white/30 dark:hover:bg-system-fill-secondary/20',
+        ghost: 'bg-white/10 text-apple-blue border border-white/20 hover:bg-white/20',
     };
 
     const sizeClasses = {
         default: 'px-4 py-2 text-sm',
         sm: 'px-2 py-1 text-xs',
     };
-    
+
     const classes = [
         baseClasses,
         sizeClasses[size],

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -7,7 +7,10 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export const Card: React.FC<CardProps> = ({ children, className, ...props }) => {
     return (
-        <div className={`bg-system-bg-primary rounded-2xl shadow-soft dark:shadow-soft-dark p-5 sm:p-6 ${className}`} {...props}>
+        <div
+            className={`w-full bg-white/30 dark:bg-system-bg-primary/30 backdrop-blur-md border border-white/20 dark:border-white/10 rounded-2xl shadow-soft dark:shadow-soft-dark p-4 sm:p-6 ${className}`}
+            {...props}
+        >
             {children}
         </div>
     );

--- a/index.html
+++ b/index.html
@@ -36,7 +36,9 @@
             --system-separator: #3a3a3c;
         }
         body {
-            background-color: var(--system-bg-secondary);
+            background: linear-gradient(135deg, #1e3a8a, #1e40af);
+            background-attachment: fixed;
+            background-size: cover;
             color: var(--system-label-primary);
         }
         .scrollbar-hide::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- refine card component with translucent glassmorphism look
- restyle buttons for glassy appearance and mobile width
- add global gradient background for blurred glass effect

## Testing
- `npm run build` *(fails: Unexpected "export" in services/api.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac89b55308833094b7cbd03767231f