### PR TITLE
feat: apply glassmorphism theme

### DIFF
--- a/components/AddClientModal.tsx
+++ b/components/AddClientModal.tsx
@@ -8,7 +8,7 @@ interface AddClientModalProps {
     addClient: (clientData: Omit<Client, 'id' | 'createdAt' | 'status' | 'timeline'>) => void;
 }
 
-const inputClasses = "mt-1 block w-full bg-system-bg-tertiary dark:bg-system-bg-secondary text-system-label-primary border border-system-separator rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
+const inputClasses = "mt-1 block w-full glass-input text-system-label-primary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
 
 export const AddClientModal: React.FC<AddClientModalProps> = ({ onClose, addClient }) => {
     const [name, setName] = useState('');
@@ -58,7 +58,7 @@ export const AddClientModal: React.FC<AddClientModalProps> = ({ onClose, addClie
     
     return (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex justify-center items-center z-50 p-4">
-            <div className="bg-system-bg-secondary rounded-2xl shadow-2xl w-full max-w-md">
+            <div className="glass rounded-2xl shadow-2xl w-full max-w-md">
                 <div className="p-6 border-b border-system-separator flex justify-between items-center">
                     <h2 className="text-xl font-semibold text-system-label-primary">Novo Cliente</h2>
                      <button onClick={onClose} className="text-system-label-secondary hover:text-system-label-primary">

--- a/components/AddProspectModal.tsx
+++ b/components/AddProspectModal.tsx
@@ -8,7 +8,7 @@ interface AddProspectModalProps {
     onAddProspect: (prospectData: Omit<Prospect, 'id'>) => void;
 }
 
-const inputClasses = "mt-1 block w-full bg-white dark:bg-apple-gray-700 text-apple-gray-900 dark:text-apple-gray-100 border border-apple-gray-300 dark:border-apple-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue placeholder-apple-gray-500 dark:placeholder-apple-gray-400";
+const inputClasses = "mt-1 block w-full glass-input text-system-label-primary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
 
 export const AddProspectModal: React.FC<AddProspectModalProps> = ({ onClose, onAddProspect }) => {
     const [name, setName] = useState('');
@@ -26,25 +26,25 @@ export const AddProspectModal: React.FC<AddProspectModalProps> = ({ onClose, onA
     };
     
     return (
-        <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex justify-center items-center z-50 p-4">
-            <div className="bg-apple-gray-100 dark:bg-apple-gray-800 rounded-xl shadow-2xl w-full max-w-md">
-                <div className="p-6 border-b border-apple-gray-200 dark:border-apple-gray-700 flex justify-between items-center">
-                    <h2 className="text-xl font-semibold text-apple-gray-800 dark:text-apple-gray-100">Novo Interessado</h2>
-                     <button onClick={onClose} className="text-apple-gray-500 hover:text-apple-gray-800 dark:hover:text-apple-gray-200">
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex justify-center items-center z-50 p-4">
+            <div className="glass rounded-xl shadow-2xl w-full max-w-md">
+                <div className="p-6 border-b border-white/20 dark:border-white/10 flex justify-between items-center">
+                    <h2 className="text-xl font-semibold text-system-label-primary">Novo Interessado</h2>
+                    <button onClick={onClose} className="text-system-label-secondary hover:text-system-label-primary">
                         <Icon name="x" className="w-6 h-6" />
                     </button>
                 </div>
                 <form onSubmit={handleSubmit} className="p-6 space-y-4">
                     <div>
-                        <label htmlFor="name" className="text-sm font-medium text-apple-gray-600 dark:text-apple-gray-400">Nome</label>
+                        <label htmlFor="name" className="text-sm font-medium text-system-label-secondary">Nome</label>
                         <input id="name" type="text" value={name} onChange={e => setName(e.target.value)} required className={inputClasses} />
                     </div>
                     <div>
-                        <label htmlFor="phone" className="text-sm font-medium text-apple-gray-600 dark:text-apple-gray-400">Telefone</label>
+                        <label htmlFor="phone" className="text-sm font-medium text-system-label-secondary">Telefone</label>
                         <input id="phone" type="tel" value={phone} onChange={e => setPhone(e.target.value)} className={inputClasses} />
                     </div>
                     <div>
-                        <label htmlFor="origin" className="text-sm font-medium text-apple-gray-600 dark:text-apple-gray-400">Origem</label>
+                        <label htmlFor="origin" className="text-sm font-medium text-system-label-secondary">Origem</label>
                         <input id="origin" type="text" value={origin} onChange={e => setOrigin(e.target.value)} className={inputClasses} />
                     </div>
                     <div className="pt-4 flex justify-end gap-3">

--- a/components/Auth.tsx
+++ b/components/Auth.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { Button } from './Button';
 import { Icon } from './Icon';
 
-const inputClasses = "mt-1 block w-full bg-system-bg-tertiary dark:bg-system-bg-secondary text-system-label-primary border border-system-separator rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
+const inputClasses = "mt-1 block w-full glass-input text-system-label-primary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
 
 const AuthForm: React.FC<{ isRegister: boolean }> = ({ isRegister }) => {
     const { login, register, error } = useAuth();
@@ -59,8 +59,8 @@ export const AuthScreen: React.FC = () => {
     const [isRegister, setIsRegister] = useState(false);
 
     return (
-        <div className="fixed inset-0 bg-system-bg-secondary flex justify-center items-center z-50 p-4">
-            <div className="bg-system-bg-primary rounded-2xl shadow-soft dark:shadow-soft-dark w-full max-w-sm">
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex justify-center items-center z-50 p-4">
+            <div className="glass rounded-2xl shadow-soft dark:shadow-soft-dark w-full max-w-sm">
                 <div className="p-6 sm:p-8">
                      <div className="text-center mb-6">
                         <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-apple-orange/15 flex items-center justify-center">
@@ -76,7 +76,7 @@ export const AuthScreen: React.FC = () => {
 
                     <AuthForm isRegister={isRegister} />
                 </div>
-                <div className="p-4 bg-system-bg-secondary rounded-b-2xl text-center">
+                <div className="p-4 glass rounded-b-2xl text-center">
                     <button onClick={() => setIsRegister(!isRegister)} className="text-sm text-apple-blue font-semibold hover:underline">
                         {isRegister ? 'Já tem uma conta? Faça login.' : 'Não tem uma conta? Registre-se.'}
                     </button>

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -7,7 +7,7 @@ interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export const Card: React.FC<CardProps> = ({ children, className, ...props }) => {
     return (
-        <div className={`bg-system-bg-primary rounded-2xl shadow-soft dark:shadow-soft-dark p-5 sm:p-6 ${className}`} {...props}>
+        <div className={`glass rounded-2xl shadow-soft dark:shadow-soft-dark p-5 sm:p-6 ${className}`} {...props}>
             {children}
         </div>
     );

--- a/components/ClientDetail.tsx
+++ b/components/ClientDetail.tsx
@@ -18,7 +18,7 @@ interface ClientDetailProps {
     deleteClient: (id: string) => Promise<boolean>;
 }
 
-const inputClasses = "block w-full bg-system-bg-tertiary dark:bg-system-bg-secondary text-system-label-primary border border-system-separator rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
+const inputClasses = "block w-full glass-input text-system-label-primary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
 const editableTypes: TimelineEventType[] = [TimelineEventType.Ligacao, TimelineEventType.Observacao, TimelineEventType.CNE, TimelineEventType.Anotacao];
 const secondaryButtonLinkClasses = "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold transition-all focus:outline-none focus:ring-2 focus:ring-apple-blue focus:ring-offset-2 dark:focus:ring-offset-system-bg-secondary disabled:opacity-50 disabled:cursor-not-allowed bg-system-fill-primary text-system-label-primary hover:bg-system-fill-secondary active:brightness-95 dark:active:brightness-105";
 
@@ -51,7 +51,7 @@ const TimelineItem: React.FC<{ event: TimelineEvent; onEdit: (event: TimelineEve
             onClick={() => isEditable && onEdit(event)}
         >
             {!isLast && <div className="absolute left-3 top-6 bottom-2 w-px bg-system-separator"></div>}
-            <div className="relative flex h-6 w-6 flex-none items-center justify-center bg-system-bg-secondary rounded-full mt-2 ring-8 ring-system-bg-primary">
+            <div className="relative flex h-6 w-6 flex-none items-center justify-center glass rounded-full mt-2 ring-8 ring-system-bg-primary">
                 {getIcon(event.type)}
             </div>
             <div className="flex-auto py-2">
@@ -367,7 +367,7 @@ export const ClientDetail: React.FC<ClientDetailProps> = ({ client, onBack, upda
     return (
         <>
             {isSaving && (
-                <div className="fixed inset-0 bg-system-bg-secondary/80 backdrop-blur-sm flex justify-center items-center z-[100]">
+                <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex justify-center items-center z-[100]">
                     <svg className="animate-spin h-10 w-10 text-apple-blue" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
@@ -450,7 +450,7 @@ export const ClientDetail: React.FC<ClientDetailProps> = ({ client, onBack, upda
                                                     disabled={isDisabled}
                                                     className={`px-2.5 py-1 text-xs font-medium rounded-full transition-all border
                                                         ${editedClient.status === opt.value ? `${opt.className} border-transparent ring-2 ring-offset-2 ring-apple-blue dark:ring-offset-system-bg-primary`
-                                                            : 'bg-system-bg-primary border-system-separator text-system-label-primary hover:bg-system-fill-primary'
+                                                            : 'glass text-system-label-primary hover:bg-white/40 dark:hover:bg-white/20'
                                                         }
                                                         ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}`
                                                     }
@@ -504,7 +504,7 @@ export const ClientDetail: React.FC<ClientDetailProps> = ({ client, onBack, upda
                                             const isDone = f.status === AutomatedFollowUpStatus.Done;
 
                                             return (
-                                                <li key={f.id} className="flex items-center justify-between p-2 rounded-lg bg-system-bg-secondary">
+                                                <li key={f.id} className="flex items-center justify-between p-2 rounded-lg glass">
                                                     <div>
                                                         <p className={`text-sm font-medium ${isOverdue ? 'text-apple-red' : 'text-system-label-primary'} ${isDone ? 'line-through text-system-label-tertiary' : ''}`}>
                                                             {new Date(f.date).toLocaleString('pt-BR', { weekday: 'short', day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' })}

--- a/components/ClientList.tsx
+++ b/components/ClientList.tsx
@@ -17,7 +17,7 @@ const ClientListItem: React.FC<{
     return (
         <li
             onClick={onSelect}
-            className="rounded-xl hover:bg-system-bg-secondary transition-colors duration-150 cursor-pointer"
+            className="rounded-xl glass hover:bg-white/40 dark:hover:bg-white/20 transition-colors duration-150 cursor-pointer"
         >
             <div className="flex items-center space-x-4 p-4">
                 <div className="flex-1 min-w-0 flex items-center space-x-3">

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -172,7 +172,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ userName, clients, onClien
         }
     };
     
-    const baseInputClasses = "bg-system-bg-primary text-system-label-primary border border-system-separator rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
+    const baseInputClasses = "glass-input text-system-label-primary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
 
     return (
         <div className="min-h-full flex flex-col">

--- a/components/EditClientModal.tsx
+++ b/components/EditClientModal.tsx
@@ -9,7 +9,7 @@ interface EditClientModalProps {
     onSave: (updatedData: Partial<Client>) => void;
 }
 
-const inputClasses = "mt-1 block w-full bg-system-bg-tertiary dark:bg-system-bg-secondary text-system-label-primary border border-system-separator rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
+const inputClasses = "mt-1 block w-full glass-input text-system-label-primary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
 
 export const EditClientModal: React.FC<EditClientModalProps> = ({ client, onClose, onSave }) => {
     const [name, setName] = useState(client.name);
@@ -59,7 +59,7 @@ export const EditClientModal: React.FC<EditClientModalProps> = ({ client, onClos
     
     return (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex justify-center items-center z-50 p-4">
-            <div className="bg-system-bg-secondary rounded-2xl shadow-2xl w-full max-w-md">
+            <div className="glass rounded-2xl shadow-2xl w-full max-w-md">
                 <div className="p-6 border-b border-system-separator flex justify-between items-center">
                     <h2 className="text-xl font-semibold text-system-label-primary">Editar Cliente</h2>
                      <button onClick={onClose} className="text-system-label-secondary hover:text-system-label-primary">

--- a/components/EditTimelineEventModal.tsx
+++ b/components/EditTimelineEventModal.tsx
@@ -11,7 +11,7 @@ interface EditTimelineEventModalProps {
     onSave: (eventId: string, updatedData: Partial<Omit<TimelineEvent, 'id' | 'date'>>) => void;
 }
 
-const inputClasses = "mt-1 block w-full bg-system-bg-tertiary dark:bg-system-bg-secondary text-system-label-primary border border-system-separator rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
+const inputClasses = "mt-1 block w-full glass-input text-system-label-primary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
 
 const parseCallContent = (content: string): { result: 'CE' | 'CNE'; reason: string; observation: string } => {
     const defaultReason = CNE_OPTIONS[1]; // N Atendeu
@@ -96,11 +96,11 @@ export const EditTimelineEventModal: React.FC<EditTimelineEventModalProps> = ({ 
                         <label className="text-sm font-medium text-system-label-secondary">Resultado</label>
                         <div className="mt-2 flex gap-4">
                              <label className="flex items-center space-x-2 cursor-pointer">
-                                <input type="radio" name="call-result" value="CE" checked={callResult === 'CE'} onChange={() => setCallResult('CE')} className="form-radio text-apple-blue focus:ring-apple-blue bg-system-bg-tertiary border-system-separator"/>
+                                <input type="radio" name="call-result" value="CE" checked={callResult === 'CE'} onChange={() => setCallResult('CE')} className="form-radio text-apple-blue focus:ring-apple-blue glass-input"/>
                                 <span className="text-sm text-system-label-primary">CE (Contato Efetivo)</span>
                             </label>
                             <label className="flex items-center space-x-2 cursor-pointer">
-                                <input type="radio" name="call-result" value="CNE" checked={callResult === 'CNE'} onChange={() => setCallResult('CNE')} className="form-radio text-apple-blue focus:ring-apple-blue bg-system-bg-tertiary border-system-separator"/>
+                                <input type="radio" name="call-result" value="CNE" checked={callResult === 'CNE'} onChange={() => setCallResult('CNE')} className="form-radio text-apple-blue focus:ring-apple-blue glass-input"/>
                                 <span className="text-sm text-system-label-primary">CNE (Contato Não Efetivo)</span>
                             </label>
                         </div>
@@ -145,7 +145,7 @@ export const EditTimelineEventModal: React.FC<EditTimelineEventModalProps> = ({ 
 
     return (
          <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex justify-center items-center z-50 p-4">
-            <div className="bg-system-bg-secondary rounded-2xl shadow-2xl w-full max-w-md">
+            <div className="glass rounded-2xl shadow-2xl w-full max-w-md">
                 <div className="p-6 border-b border-system-separator flex justify-between items-center">
                     <h2 className="text-xl font-semibold text-system-label-primary">Editar Evento da Timeline</h2>
                     <button onClick={onClose} className="text-system-label-secondary hover:text-system-label-primary">

--- a/components/EulaModal.tsx
+++ b/components/EulaModal.tsx
@@ -11,8 +11,8 @@ export const EulaModal: React.FC<EulaModalProps> = ({ onAccept }) => {
     const [isChecked, setIsChecked] = useState(false);
 
     return (
-        <div className="fixed inset-0 bg-system-bg-secondary flex justify-center items-center z-[100] p-4">
-            <div className="bg-system-bg-primary rounded-2xl shadow-2xl w-full max-w-2xl h-[90vh] flex flex-col">
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex justify-center items-center z-[100] p-4">
+            <div className="glass rounded-2xl shadow-2xl w-full max-w-2xl h-[90vh] flex flex-col">
                 <div className="p-6 border-b border-system-separator flex-shrink-0">
                     <h2 className="text-2xl font-bold text-system-label-primary">Acordo de Licença de Usuário Final (EULA)</h2>
                 </div>
@@ -83,7 +83,7 @@ export const EulaModal: React.FC<EulaModalProps> = ({ onAccept }) => {
                             type="checkbox" 
                             checked={isChecked} 
                             onChange={() => setIsChecked(!isChecked)} 
-                            className="form-checkbox h-5 w-5 rounded text-apple-blue bg-system-bg-tertiary border-system-separator focus:ring-apple-blue"
+                            className="form-checkbox h-5 w-5 rounded text-apple-blue glass-input focus:ring-apple-blue"
                         />
                         <span className="text-sm text-system-label-primary">Eu li e concordo com os termos e condições.</span>
                     </label>

--- a/components/FunnelModal.tsx
+++ b/components/FunnelModal.tsx
@@ -53,7 +53,7 @@ const FunnelStep: React.FC<{
                      <div className="h-8 w-px bg-system-separator"></div>
                 </div>
             )}
-            <div className="flex items-center gap-4 p-4 rounded-xl bg-system-bg-primary w-full max-w-xs justify-between">
+            <div className="flex items-center gap-4 p-4 rounded-xl glass w-full max-w-xs justify-between">
                 <span className="text-sm font-medium text-system-label-primary">{label}</span>
                 <span className="text-lg font-bold text-system-label-primary">{value}</span>
             </div>
@@ -94,7 +94,7 @@ export const FunnelModal: React.FC<FunnelModalProps> = ({ onClose, metrics }) =>
     
     return (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex justify-center items-center z-50 p-4">
-            <div className="bg-system-bg-secondary rounded-2xl shadow-2xl w-full max-w-sm">
+            <div className="glass rounded-2xl shadow-2xl w-full max-w-sm">
                 <div className="p-6 border-b border-system-separator flex justify-between items-center">
                     <h2 className="text-xl font-semibold text-system-label-primary">Funil de Vendas do Dia</h2>
                      <button onClick={onClose} className="text-system-label-secondary hover:text-system-label-primary">

--- a/components/ImportClientsModal.tsx
+++ b/components/ImportClientsModal.tsx
@@ -25,7 +25,7 @@ const OPTIONAL_FIELDS: Record<string, string> = {
     anexos: 'Anexos (JSON)'
 };
 
-const baseInputClasses = "block w-full bg-system-bg-tertiary dark:bg-system-bg-secondary text-system-label-primary border border-system-separator rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
+const baseInputClasses = "block w-full glass-input text-system-label-primary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
 
 
 export const ImportClientsModal: React.FC<ImportClientsModalProps> = ({ onClose, onImport }) => {
@@ -131,7 +131,7 @@ export const ImportClientsModal: React.FC<ImportClientsModalProps> = ({ onClose,
             case 'UPLOAD':
                 return (
                     <div className="text-center">
-                        <label htmlFor="csv-upload" className="flex flex-col items-center justify-center w-full h-48 border-2 border-system-separator border-dashed rounded-lg cursor-pointer bg-system-bg-tertiary hover:bg-system-fill-primary">
+                        <label htmlFor="csv-upload" className="flex flex-col items-center justify-center w-full h-48 border-2 border-system-separator border-dashed rounded-lg cursor-pointer glass hover:bg-white/40 dark:hover:bg-black/40">
                             <div className="flex flex-col items-center justify-center pt-5 pb-6">
                                 <Icon name="upload" className="w-10 h-10 mb-3 text-system-label-secondary" />
                                 <p className="mb-2 text-sm text-system-label-secondary"><span className="font-semibold">Clique para enviar</span> ou arraste e solte</p>
@@ -149,12 +149,12 @@ export const ImportClientsModal: React.FC<ImportClientsModalProps> = ({ onClose,
                         <p className="text-sm text-system-label-secondary">Combine as colunas do seu arquivo CSV com os campos do CRM. <strong className="text-system-label-primary">Nome</strong> e <strong className="text-system-label-primary">Telefone</strong> são obrigatórios.</p>
                         
                         <fieldset className="space-y-4 border-t border-system-separator pt-4">
-                            <legend className="text-xs font-semibold text-system-label-secondary uppercase -translate-y-6 bg-system-bg-secondary px-2">Campos Obrigatórios</legend>
+                            <legend className="text-xs font-semibold text-system-label-secondary uppercase -translate-y-6 bg-white/20 dark:bg-black/20 px-2">Campos Obrigatórios</legend>
                              {Object.entries(REQUIRED_FIELDS).map(([fieldKey, fieldLabel]) => <MappingField key={fieldKey} fieldKey={fieldKey} fieldLabel={fieldLabel} />)}
                         </fieldset>
 
                         <fieldset className="space-y-4 border-t border-system-separator pt-4">
-                            <legend className="text-xs font-semibold text-system-label-secondary uppercase -translate-y-6 bg-system-bg-secondary px-2">Campos Opcionais (Histórico)</legend>
+                            <legend className="text-xs font-semibold text-system-label-secondary uppercase -translate-y-6 bg-white/20 dark:bg-black/20 px-2">Campos Opcionais (Histórico)</legend>
                             {Object.entries(OPTIONAL_FIELDS).map(([fieldKey, fieldLabel]) => <MappingField key={fieldKey} fieldKey={fieldKey} fieldLabel={fieldLabel} />)}
                         </fieldset>
                     </div>
@@ -201,7 +201,7 @@ export const ImportClientsModal: React.FC<ImportClientsModalProps> = ({ onClose,
 
     return (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex justify-center items-center z-50 p-4">
-            <div className="bg-system-bg-secondary rounded-2xl shadow-2xl w-full max-w-lg">
+            <div className="glass rounded-2xl shadow-2xl w-full max-w-lg">
                 <div className="p-6 border-b border-system-separator flex justify-between items-center">
                     <h2 className="text-xl font-semibold text-system-label-primary">{getModalTitle()}</h2>
                      <button onClick={onClose} className="text-system-label-secondary hover:text-system-label-primary">

--- a/components/LeadPool.tsx
+++ b/components/LeadPool.tsx
@@ -98,7 +98,7 @@ export const LeadPool: React.FC = () => {
                 
                 <div className="flex items-center gap-2">
                   <select
-                    className="bg-system-bg-primary text-system-label-primary border border-system-separator rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue"
+                    className="glass-input text-system-label-primary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue"
                     onChange={(e) => {
                       if (e.target.value) {
                         handleAssignLead(lead._id!, e.target.value);

--- a/components/LogCallModal.tsx
+++ b/components/LogCallModal.tsx
@@ -8,7 +8,7 @@ interface LogCallModalProps {
     onLogCall: (result: 'CE' | 'CNE', observation: string) => void;
 }
 
-const inputClasses = "mt-1 block w-full bg-system-bg-tertiary dark:bg-system-bg-secondary text-system-label-primary border border-system-separator rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
+const inputClasses = "mt-1 block w-full glass-input text-system-label-primary rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
 
 export const LogCallModal: React.FC<LogCallModalProps> = ({ onClose, onLogCall }) => {
     const [result, setResult] = useState<'CE' | 'CNE'>('CE');
@@ -27,7 +27,7 @@ export const LogCallModal: React.FC<LogCallModalProps> = ({ onClose, onLogCall }
 
     return (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex justify-center items-center z-50 p-4">
-            <div className="bg-system-bg-secondary rounded-2xl shadow-2xl w-full max-w-md">
+            <div className="glass rounded-2xl shadow-2xl w-full max-w-md">
                 <div className="p-6 border-b border-system-separator flex justify-between items-center">
                     <h2 className="text-xl font-semibold text-system-label-primary">Registrar Resultado da Ligação</h2>
                     <button onClick={onClose} className="text-system-label-secondary hover:text-system-label-primary">
@@ -39,11 +39,11 @@ export const LogCallModal: React.FC<LogCallModalProps> = ({ onClose, onLogCall }
                         <label className="text-sm font-medium text-system-label-secondary">Resultado</label>
                         <div className="mt-2 flex gap-4">
                             <label className="flex items-center space-x-2 cursor-pointer">
-                                <input type="radio" name="call-result" value="CE" checked={result === 'CE'} onChange={() => setResult('CE')} className="form-radio text-apple-blue focus:ring-apple-blue bg-system-bg-tertiary border-system-separator"/>
+                                <input type="radio" name="call-result" value="CE" checked={result === 'CE'} onChange={() => setResult('CE')} className="form-radio text-apple-blue focus:ring-apple-blue glass-input"/>
                                 <span className="text-sm text-system-label-primary">CE (Contato Efetivo)</span>
                             </label>
                             <label className="flex items-center space-x-2 cursor-pointer">
-                                <input type="radio" name="call-result" value="CNE" checked={result === 'CNE'} onChange={() => setResult('CNE')} className="form-radio text-apple-blue focus:ring-apple-blue bg-system-bg-tertiary border-system-separator"/>
+                                <input type="radio" name="call-result" value="CNE" checked={result === 'CNE'} onChange={() => setResult('CNE')} className="form-radio text-apple-blue focus:ring-apple-blue glass-input"/>
                                 <span className="text-sm text-system-label-primary">CNE (Contato Não Efetivo)</span>
                             </label>
                         </div>

--- a/components/UserNamePrompt.tsx
+++ b/components/UserNamePrompt.tsx
@@ -6,7 +6,7 @@ interface UserNamePromptProps {
     onNameSet: (name: string) => void;
 }
 
-const inputClasses = "mt-2 block w-full bg-system-bg-primary text-system-label-primary border border-system-separator rounded-lg px-3 py-2 text-base text-center focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
+const inputClasses = "mt-2 block w-full glass-input text-system-label-primary rounded-lg px-3 py-2 text-base text-center focus:outline-none focus:ring-2 focus:ring-apple-blue focus:border-transparent placeholder-system-label-tertiary";
 
 export const UserNamePrompt: React.FC<UserNamePromptProps> = ({ onNameSet }) => {
     const [name, setName] = useState('');
@@ -19,8 +19,8 @@ export const UserNamePrompt: React.FC<UserNamePromptProps> = ({ onNameSet }) => 
     };
 
     return (
-        <div className="fixed inset-0 bg-system-bg-secondary flex justify-center items-center z-50 p-4">
-            <div className="w-full max-w-sm text-center">
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex justify-center items-center z-50 p-4">
+            <div className="w-full max-w-sm text-center glass p-6 rounded-2xl">
                  <Icon name="user" className="w-16 h-16 mx-auto text-system-label-tertiary mb-4" />
                 <h1 className="text-2xl font-bold text-system-label-primary">Bem-vindo(a)!</h1>
                 <p className="text-system-label-secondary mt-2">Para começar, por favor, insira seu nome. Ele será usado para identificar seus relatórios exportados.</p>

--- a/index.html
+++ b/index.html
@@ -36,8 +36,27 @@
             --system-separator: #3a3a3c;
         }
         body {
-            background-color: var(--system-bg-secondary);
             color: var(--system-label-primary);
+        }
+        .glass {
+            background: rgba(255, 255, 255, 0.2);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            backdrop-filter: blur(16px);
+            -webkit-backdrop-filter: blur(16px);
+        }
+        .dark .glass {
+            background: rgba(0, 0, 0, 0.3);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+        .glass-input {
+            background: rgba(255, 255, 255, 0.3);
+            border: 1px solid rgba(255, 255, 255, 0.4);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+        }
+        .dark .glass-input {
+            background: rgba(0, 0, 0, 0.3);
+            border: 1px solid rgba(255, 255, 255, 0.1);
         }
         .scrollbar-hide::-webkit-scrollbar {
             display: none;
@@ -99,7 +118,7 @@
 }
 </script>
 </head>
-<body class="bg-system-bg-secondary antialiased dark">
+<body class="min-h-screen bg-gradient-to-br from-blue-400 via-purple-500 to-pink-500 dark:from-gray-900 dark:via-gray-800 dark:to-black antialiased dark">
 <div id="root"></div>
 <script type="module" src="/index.tsx"></script>
 </body>


### PR DESCRIPTION
## Summary
- add global glass and glass-input utilities with gradient backdrop
- update cards, modals and forms to use transparent blurred glass style
- introduce glass containers for user prompts and imports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Unexpected "export" in services/api.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9df4272c8330960136d5d58ad7a6